### PR TITLE
Add compound interest calculator

### DIFF
--- a/apps/CompoundInterestCalculator.tsx
+++ b/apps/CompoundInterestCalculator.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useMemo } from 'react';
+
+const CompoundInterestCalculator: React.FC = () => {
+  const [principal, setPrincipal] = useState('1000');
+  const [rate, setRate] = useState('5');
+  const [times, setTimes] = useState('12');
+  const [years, setYears] = useState('10');
+
+  const result = useMemo(() => {
+    const p = parseFloat(principal);
+    const r = parseFloat(rate) / 100;
+    const n = parseFloat(times);
+    const t = parseFloat(years);
+
+    if (!p || !r || !n || !t || p <= 0 || n <= 0 || t <= 0) {
+      return null;
+    }
+
+    const amount = p * Math.pow(1 + r / n, n * t);
+    const interest = amount - p;
+
+    return {
+      amount: amount.toFixed(2),
+      interest: interest.toFixed(2)
+    };
+  }, [principal, rate, times, years]);
+
+  return (
+    <div className="max-w-lg mx-auto">
+      <div className="space-y-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Principal ($)</label>
+          <input
+            type="number"
+            value={principal}
+            onChange={e => setPrincipal(e.target.value)}
+            className="mt-1 block w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Annual Interest Rate (%)</label>
+          <input
+            type="number"
+            step="0.1"
+            value={rate}
+            onChange={e => setRate(e.target.value)}
+            className="mt-1 block w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Compounds Per Year</label>
+          <input
+            type="number"
+            value={times}
+            onChange={e => setTimes(e.target.value)}
+            className="mt-1 block w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Years</label>
+          <input
+            type="number"
+            value={years}
+            onChange={e => setYears(e.target.value)}
+            className="mt-1 block w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+          />
+        </div>
+      </div>
+      {result && (
+        <div className="mt-8 bg-gray-100 dark:bg-gray-800 p-6 rounded-lg">
+          <div className="text-center mb-6">
+            <p className="text-lg text-gray-600 dark:text-gray-400">Future Value</p>
+            <p className="text-5xl font-bold text-indigo-600 dark:text-indigo-400">${result.amount}</p>
+          </div>
+          <div className="text-center text-lg">
+            <p className="text-gray-500 dark:text-gray-400">Total Interest Earned</p>
+            <p className="font-semibold">${result.interest}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CompoundInterestCalculator;

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -39,6 +39,10 @@ export const EmiIcon: React.FC<{ className?: string }> = ({ className }) => (
   <svg className={className} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
 );
 
+export const CompoundIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 17l6-6 4 4 8-8"/><path d="M14 7h7v7"/></svg>
+);
+
 export const AiIcon: React.FC<{ className?: string }> = ({ className }) => (
   <svg className={className} xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 8V4H8"/><rect x="4" y="12" width="16" height="8" rx="2"/><path d="M6 12v-2a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M12 12v8"/></svg>
 );

--- a/constants.tsx
+++ b/constants.tsx
@@ -1,7 +1,8 @@
 import { AppDefinition, AppCategory } from './types.ts';
 import BMICalculator from './apps/BMICalculator.tsx';
 import EMICalculator from './apps/EMICalculator.tsx';
-import { BmiIcon, EmiIcon } from './components/Icons.tsx';
+import CompoundInterestCalculator from './apps/CompoundInterestCalculator.tsx';
+import { BmiIcon, EmiIcon, CompoundIcon } from './components/Icons.tsx';
 
 export const APPS_DATA: AppDefinition[] = [
   {
@@ -23,5 +24,15 @@ export const APPS_DATA: AppDefinition[] = [
     isPremium: true,
     Icon: EmiIcon,
     AppComponent: EMICalculator,
+  },
+  {
+    id: 'compound-interest-calculator',
+    title: 'Compound Interest',
+    category: AppCategory.Finance,
+    description: 'Estimate growth with compounding.',
+    longDescription: 'Quickly calculate how your investments grow over time with regular compounding. Adjust interest rate, compounding frequency, and duration to see future value and total interest earned.',
+    isPremium: false,
+    Icon: CompoundIcon,
+    AppComponent: CompoundInterestCalculator,
   },
 ];


### PR DESCRIPTION
## Summary
- add a new Compound Interest Calculator app
- add CompoundIcon
- register the new app in the constants

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f9169ba0083308413020b542554cc