### PR TITLE
Fix blank PDF export in Resume Builder

### DIFF
--- a/apps/ResumeBuilder.tsx
+++ b/apps/ResumeBuilder.tsx
@@ -110,8 +110,13 @@ const ResumeBuilder: React.FC = () => {
     const html2pdf = (window as any).html2pdf;
     if (element && typeof html2pdf === 'function') {
       html2pdf()
+        .set({
+          filename: 'resume.pdf',
+          html2canvas: { useCORS: true, scale: 2 },
+          jsPDF: { format: 'a4' },
+        })
         .from(element)
-        .save('resume.pdf');
+        .save();
     }
   };
 


### PR DESCRIPTION
## Summary
- allow html2pdf to use cross-origin resources when exporting resume

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f9baf5c008330b0d626bade9b2f54