### PR TITLE
Add standalone fullscreen mode for notebook

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,13 +10,15 @@ import DashboardPage from './pages/DashboardPage.tsx';
 import NotFoundPage from './pages/NotFoundPage.tsx';
 
 function App() {
+  const params = new URLSearchParams(window.location.search);
+  const bare = params.get('bare') === '1';
   return (
     <ThemeProvider>
       <AuthProvider>
         <HashRouter>
           <div className="flex flex-col min-h-screen bg-white dark:bg-black text-gray-900 dark:text-gray-100 font-sans transition-colors duration-300">
-            <Header />
-            <main className="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+            {!bare && <Header />}
+            <main className={bare ? 'flex-grow p-0 m-0' : 'flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8'}>
               <Routes>
                 <Route path="/" element={<HomePage />} />
                 <Route path="/app/:appId" element={<AppDetailPage />} />
@@ -24,7 +26,7 @@ function App() {
                 <Route path="*" element={<NotFoundPage />} />
               </Routes>
             </main>
-            <Footer />
+            {!bare && <Footer />}
           </div>
         </HashRouter>
       </AuthProvider>

--- a/apps/MultiSurfaceNotebook.tsx
+++ b/apps/MultiSurfaceNotebook.tsx
@@ -20,7 +20,8 @@ const MultiSurfaceNotebook: React.FC = () => {
   const [fullScreen, setFullScreen] = useState(startFull);
   const openInNewTab = () => {
     const url = new URL(window.location.href);
-    url.searchParams.set('fullscreen', '1');
+    url.searchParams.set('bare', '1');
+    url.hash = '#/app/multi-surface-notebook?fullscreen=1';
     window.open(url.toString(), '_blank');
   };
   return (

--- a/pages/AppDetailPage.tsx
+++ b/pages/AppDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useLocation } from 'react-router-dom';
 import { APPS_DATA } from '../constants.tsx';
 import { AppDefinition } from '../types.ts';
 import { useAuth } from '../hooks/useAuth.ts';
@@ -9,6 +9,8 @@ import NotFoundPage from './NotFoundPage.tsx';
 
 const AppDetailPage: React.FC = () => {
   const { appId } = useParams<{ appId: string }>();
+  const location = useLocation();
+  const bare = new URLSearchParams(location.search).get('bare') === '1';
   const [app, setApp] = useState<AppDefinition | null>(null);
   const { isSubscribed, subscribe } = useAuth();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -29,6 +31,10 @@ const AppDetailPage: React.FC = () => {
     setIsModalOpen(true);
   };
   
+  if (bare) {
+    return <app.AppComponent />;
+  }
+
   return (
     <div className="max-w-4xl mx-auto">
       {isModalOpen && <SubscriptionModal onClose={() => setIsModalOpen(false)} />}


### PR DESCRIPTION
## Summary
- allow hiding header and footer when URL contains `bare=1`
- handle `bare` query param in AppDetailPage
- update MultiSurfaceNotebook to open dedicated fullscreen page in new tab

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fba90aacc8330afd500f0a6ea29d3